### PR TITLE
feat(python): fix for extra annotation type and add dataset response schema

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -4,6 +4,7 @@ Use Dataverse-SDK for Python to help you to interact with the Dataverse platform
   - Create Project with your input ontology and sensors
   - Get Project by project-id
   - Create Dataset from your AWS/Azure storage or local
+  - Get Dataset by dataset-id
 
 [Package (PyPi)](https://test.pypi.org/project/dataverse-sdk/)    |   [Source code](https://github.com/linkernetworks/dataverse-sdk)
 
@@ -42,6 +43,7 @@ The following sections provide examples for the most common DataVerse tasksm inc
 * [Create Project](#create-project)
 * [Get Project](#get-project)
 * [Create Dataset](#create-dataset)
+* [Get Dataset](#get-dataset)
 
 
 ### Create Project
@@ -81,7 +83,7 @@ project = client.get_project(id)
 
 ### Create Dataset
 
-Use `create_dataset` to create dataset from cloud storage
+* Use `create_dataset` to create dataset from **cloud storage**
 
 ```Python
 dataset_data = {
@@ -100,6 +102,36 @@ dataset_data = {
 }
 dataset = project.create_dataset(**dataset_data)
 ```
+
+* Use `create_dataset` to create dataset from **your local directory**
+
+```Python
+dataset_data = {
+    "data_source": DataSource.SDK,
+    "storage_url" : "",
+    "container_name": "",
+    "sas_token":"",
+    "data_folder": "/path/to/your_localdir",
+    "name": "Dataset Local Upload",
+    "type": DatasetType.ANNOTATED_DATA,
+    "generate_metadata": False,
+    "render_pcd": False,
+    "annotation_format": AnnotationFormat.VISION_AI,
+    "sequential": False,
+    "sensors": project.sensors,
+    "extra_annotations" :['model_name']  #optional
+}
+dataset = project.create_dataset(**dataset_data)
+```
+
+## Get Dataset
+
+The `get_dataset` method retrieves the dataset info from the connected site. The `id` parameter is the unique interger ID of the dataset, not its "name" property.
+
+```Python
+dataset = client.get_dataset(id)
+```
+
 
 ## Troubleshooting
 

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -175,6 +175,7 @@ class BackendAPI:
         container_name: Optional[str] = None,
         sas_token: Optional[str] = None,
         description: Optional[str] = None,
+        extra_annotations: Optional[list[str]] = None,
     ) -> dict:
         resp = self.send_request(
             url=f"{self.host}/api/datasets/",
@@ -195,6 +196,7 @@ class BackendAPI:
                 "generate_metadata": generate_metadata,
                 "render_pcd": render_pcd,
                 "description": description if description else "",
+                "extra_annotations": extra_annotations if extra_annotations else [],
             },
         )
         return resp.json()

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -201,7 +201,6 @@ class BackendAPI:
         )
         return resp.json()
 
-    # TODO: add dataset response schema
     def get_dataset(self, dataset_id: int):
         resp = self.send_request(
             url=f"{self.host}/api/datasets/{dataset_id}/",

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -185,6 +185,31 @@ class DataverseClient:
             raise ClientConnectionError(f"Failed to get the project: {e}")
         return Project.create(project_data)
 
+    def get_dataset(self, dataset_id: int):
+        """Get dataset detail and status by id
+
+        Parameters
+        ----------
+        dataset_id : int
+            dataset-id in db
+
+        Returns
+        -------
+        Dataset
+            dataset basemodel from host response for client usage
+
+        Raises
+        ------
+        ClientConnectionError
+            raise exception if there is any error occurs when calling backend APIs.
+        """
+
+        try:
+            dataset_data: dict = self._api_client.get_dataset(dataset_id=dataset_id)
+        except Exception as e:
+            raise ClientConnectionError(f"Failed to get the dataset: {e}")
+        return Dataset.create(dataset_data)
+
     @staticmethod
     def create_dataset(
         name: str,

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -214,7 +214,7 @@ class DataverseClient:
             Sensor.create(sensor_data) for sensor_data in dataset_data["sensors"]
         ]
         dataset_data.update({"project": project, "sensors": sensors})
-        return Dataset.create(dataset_data)
+        return Dataset(**dataset_data)
 
     # TODO: required arguments for different DataSource
     @staticmethod
@@ -332,7 +332,7 @@ class DataverseClient:
         )
 
         if data_source in {DataSource.Azure, DataSource.AWS}:
-            return Dataset.create(dataset_data)
+            return Dataset(**dataset_data)
 
         # start uploading from local
         folder_paths: list[Optional[str]] = [
@@ -385,4 +385,4 @@ class DataverseClient:
         except Exception as e:
             raise ClientConnectionError(f"failed to upload files: {e}")
 
-        return Dataset.create(dataset_data)
+        return Dataset(**dataset_data)

--- a/python/dataverse_sdk/schemas/api.py
+++ b/python/dataverse_sdk/schemas/api.py
@@ -98,4 +98,4 @@ class DatasetAPISchema(BaseModel):
     annotation_folder: Optional[str] = None
     lidar_folder: Optional[str] = None
     render_pcd: Optional[str] = None
-    extra_annotations: Optional[str] = None
+    extra_annotations: Optional[list[str]] = None

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -240,22 +240,3 @@ class Dataset(BaseModel):
 
     class Config:
         extra = "allow"
-
-    @classmethod
-    def create(cls, dataset_data: dict) -> "Dataset":
-        return cls(
-            id=dataset_data["id"],
-            name=dataset_data["name"],
-            project=dataset_data["project"],
-            sensors=dataset_data["sensors"],
-            data_source=dataset_data["data_source"],
-            annotation_format=dataset_data["annotation_format"],
-            description=dataset_data["description"],
-            status=dataset_data["status"],
-            sequential=dataset_data["sequential"],
-            generate_metadata=dataset_data["generate_metadata"],
-            type=dataset_data["type"],
-            file_count=dataset_data["file_count"],
-            image_count=dataset_data["image_count"],
-            pcd_count=dataset_data["pcd_count"],
-        )

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -243,12 +243,11 @@ class Dataset(BaseModel):
 
     @classmethod
     def create(cls, dataset_data: dict) -> "Dataset":
-        sensor_list = [Sensor(**sensor) for sensor in dataset_data["sensors"]]
         return cls(
             id=dataset_data["id"],
             name=dataset_data["name"],
-            project=Project(sensors=sensor_list, **dataset_data["project"]),
-            sensors=sensor_list,
+            project=dataset_data["project"],
+            sensors=dataset_data["sensors"],
             data_source=dataset_data["data_source"],
             annotation_format=dataset_data["annotation_format"],
             description=dataset_data["description"],

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -240,3 +240,23 @@ class Dataset(BaseModel):
 
     class Config:
         extra = "allow"
+
+    @classmethod
+    def create(cls, dataset_data: dict) -> "Dataset":
+        sensor_list = [Sensor(**sensor) for sensor in dataset_data["sensors"]]
+        return cls(
+            id=dataset_data["id"],
+            name=dataset_data["name"],
+            project=Project(sensors=sensor_list, **dataset_data["project"]),
+            sensors=sensor_list,
+            data_source=dataset_data["data_source"],
+            annotation_format=dataset_data["annotation_format"],
+            description=dataset_data["description"],
+            status=dataset_data["status"],
+            sequential=dataset_data["sequential"],
+            generate_metadata=dataset_data["generate_metadata"],
+            type=dataset_data["type"],
+            file_count=dataset_data["file_count"],
+            image_count=dataset_data["image_count"],
+            pcd_count=dataset_data["pcd_count"],
+        )


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
Fix for extra annotation type and add dataset response schema

## What Changes?

<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- Fix the data type of extra_annotations
- Add `get_dataset` function in `DataverseClient` class
- Add `create` method for processing response from dataset api
- update README

## What to Check?

<!-- Describe steps to verify the functions of this PR -->
1. We could get_dataset with id from client
```Python
dataset = client.get_dataset(id)
```
2. Using create dataset could input extra_annotations