### PR TITLE
feat(python): be able to create project with project tag

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -70,7 +70,19 @@ sensors = [
     Sensor(name="camera 1", type=SensorType.CAMERA),
     Sensor(name="lidar 1", type=SensorType.LIDAR),
 ]
-project = client.create_project(name="test project", ontology=ontology, sensors=sensors)
+project_tag = ProjectTag( attributes= [
+            {
+                "name": "year",
+                "type": "number"
+            },
+            {
+                "name": "unknown_object",
+                "type": "option",
+                "options": [{"value":"fire"}, {"value":"leaves"}, {"value":"water"}
+                ]
+            }])
+
+project = client.create_project(name="test project", ontology=ontology, sensors=sensors, project_tag=project_tag)
 ```
 
 ### Get Project
@@ -146,4 +158,3 @@ dataset = client.get_dataset(id)
 ## Links to language repos
 
 [Python Readme](https://github.com/linkernetworks/dataverse-sdk/tree/develop/python/README.md)
-

--- a/python/README.md
+++ b/python/README.md
@@ -70,17 +70,16 @@ sensors = [
     Sensor(name="camera 1", type=SensorType.CAMERA),
     Sensor(name="lidar 1", type=SensorType.LIDAR),
 ]
-project_tag = ProjectTag( attributes= [
-            {
-                "name": "year",
-                "type": "number"
-            },
-            {
-                "name": "unknown_object",
-                "type": "option",
-                "options": [{"value":"fire"}, {"value":"leaves"}, {"value":"water"}
-                ]
-            }])
+project_tag = ProjectTag(
+    attributes=[
+        {"name": "year", "type": "number"},
+        {
+            "name": "unknown_object",
+            "type": "option",
+            "options": [{"value": "fire"}, {"value": "leaves"}, {"value": "water"}],
+        },
+    ]
+)
 
 project = client.create_project(name="test project", ontology=ontology, sensors=sensors, project_tag=project_tag)
 ```

--- a/python/dataverse_sdk/__init__.py
+++ b/python/dataverse_sdk/__init__.py
@@ -8,6 +8,7 @@ from .schemas.client import (
     Ontology,
     OntologyClass,
     Project,
+    ProjectTag,
     Sensor,
 )
 from .schemas.common import (
@@ -35,6 +36,7 @@ __all__ = [
     "Project",
     "Dataset",
     "Sensor",
+    "ProjectTag",
     "connections",
     "AnnotationFormat",
     "DatasetType",

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -140,8 +140,8 @@ class BackendAPI:
         name: str,
         ontology_data: dict,
         sensor_data: list[dict],
-        project_tag_data: dict = None,
-        description: str = None,
+        project_tag_data: Optional[dict] = None,
+        description: Optional[str] = None,
     ) -> dict:
         resp = self.send_request(
             url=f"{self.host}/api/projects/",

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -136,7 +136,12 @@ class BackendAPI:
         self.headers["Authorization"] = f"Bearer {access_token}"
 
     def create_project(
-        self, name: str, ontology_data: dict, sensor_data: list[dict]
+        self,
+        name: str,
+        ontology_data: dict,
+        sensor_data: list[dict],
+        project_tag_data: dict = None,
+        description: str = None,
     ) -> dict:
         resp = self.send_request(
             url=f"{self.host}/api/projects/",
@@ -146,6 +151,8 @@ class BackendAPI:
                 "name": name,
                 "ontology_data": ontology_data,
                 "sensor_data": sensor_data,
+                "project_tag_data": project_tag_data,
+                "description": description,
             },
         )
 

--- a/python/dataverse_sdk/schemas/api.py
+++ b/python/dataverse_sdk/schemas/api.py
@@ -31,6 +31,13 @@ class AttributeAPISchema(BaseModel):
         return value
 
 
+class ProjectTagAPISchema(BaseModel):
+    attribute_data: Optional[list[AttributeAPISchema]] = None
+
+    class Config:
+        use_enum_values = True
+
+
 class SensorAPISchema(BaseModel):
     id: Optional[int] = None
     name: str
@@ -76,6 +83,7 @@ class ProjectAPISchema(BaseModel):
     ego_car: Optional[str] = None
     ontology_data: OntologyAPISchema
     sensor_data: list[SensorAPISchema]
+    project_tag_data: ProjectTagAPISchema
 
 
 class DatasetAPISchema(BaseModel):

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -39,13 +39,21 @@ class Attribute(BaseModel):
         return value
 
 
+class ProjectTag(BaseModel):
+    attributes: Optional[list[Attribute]] = None
+
+    class Config:
+        use_enum_values = True
+
+    @classmethod
+    def create(cls, project_tag_data: dict) -> "ProjectTag":
+        return cls(**project_tag_data)
+
+
 class Sensor(BaseModel):
     id: Optional[int] = None
     name: str
     type: SensorType
-
-    class Config:
-        use_enum_values = True
 
     @classmethod
     def create(cls, sensor_data: dict) -> "Sensor":
@@ -88,7 +96,7 @@ class Ontology(BaseModel):
                 name=cls_["name"],
                 color=cls_["color"],
                 rank=cls_["rank"],
-                # TODO: attributes
+                attributes=cls_["attributes"],
             )
             for cls_ in ontology_data["classes"]
         ]
@@ -123,6 +131,7 @@ class Project(BaseModel):
     ego_car: Optional[str] = None
     ontology: Ontology
     sensors: list[Sensor]
+    project_tag: Optional[ProjectTag] = None
 
     @classmethod
     def create(cls, project_data: dict) -> "Project":
@@ -130,6 +139,7 @@ class Project(BaseModel):
         sensors = [
             Sensor.create(sensor_data) for sensor_data in project_data["sensors"]
         ]
+        project_tag = ProjectTag.create(project_data["project_tag"])
         return cls(
             id=project_data["id"],
             name=project_data["name"],
@@ -137,6 +147,7 @@ class Project(BaseModel):
             ego_car=project_data["ego_car"],
             ontology=ontology,
             sensors=sensors,
+            project_tag=project_tag,
         )
 
     def create_dataset(

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -55,6 +55,9 @@ class Sensor(BaseModel):
     name: str
     type: SensorType
 
+    class Config:
+        use_enum_values = True
+
     @classmethod
     def create(cls, sensor_data: dict) -> "Sensor":
         return cls(**sensor_data)

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "0.1.0"
+PACKAGE_VERSION = "0.1.1"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose
- Be able to create project with project tags by SDK
- [AB#12220](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/12220)

## What Changes?
- Add project_tag schema and arguments for creating project with project_tag

## What to Check?
```
## create project_tag
project_tag = ProjectTag( attributes= [            
            {
                "name": "year",
                "type": "number"
            },
            {
                "name": "unknown_object",
                "type": "option",
                "options": [{"value":"fire"}, {"value":"leaves"}, {"value":"water"}
                ]
            }])
## create project with project_tag
project = client.create_project(name ='sdk_test', sensors = sensors, ontology = ontology, project_tag = project_tag)


```