### PR TITLE
feat(python): be able to download model related files from api request

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -175,8 +175,8 @@ model = project.get_model(model_id=30)
 ```
 From the given model, we could get the label file and the triton model file by the commands below.
 ```Python
-model.get_label_file()
-model.get_triton_model_file()
+model.get_label_file(save_path="./labels.txt", timeout=6000)
+model.get_triton_model_file(save_path="./model.zip", timeout=6000)
 
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -175,8 +175,8 @@ model = project.get_model(model_id=30)
 ```
 From the given model, we could get the label file and the triton model file by the commands below.
 ```Python
-model.get_label_file(save_path="./labels.txt", timeout=6000)
-model.get_triton_model_file(save_path="./model.zip", timeout=6000)
+status, label_file_path = model.get_label_file(save_path="./labels.txt", timeout=6000)
+status, label_file_path = model.get_triton_model_file(save_path="./model.zip", timeout=6000)
 
 ```
 

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -47,7 +47,6 @@ class BackendAPI:
         attempts: int = 1,
         max_attempts: int = 5,
         data: Optional[Union[str, dict]] = None,
-        stream: bool = False,
         timeout: int = 3000,
         **kwargs,
     ):
@@ -61,8 +60,6 @@ class BackendAPI:
             and kwargs.get("headers", {}).get("Content-Type") == "application/json"
         ):
             data = json.dumps(data)
-        if stream:
-            kwargs["stream"] = stream
 
         parent_func = inspect.stack()[2][3]
         try:

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -1,7 +1,6 @@
 import inspect
 import json
 import logging
-from io import BytesIO
 from typing import Optional, Union
 from urllib.parse import urlencode
 
@@ -48,6 +47,8 @@ class BackendAPI:
         attempts: int = 1,
         max_attempts: int = 5,
         data: Optional[Union[str, dict]] = None,
+        stream: bool = False,
+        timeout: int = 3000,
         **kwargs,
     ):
         if attempts > max_attempts:
@@ -60,13 +61,17 @@ class BackendAPI:
             and kwargs.get("headers", {}).get("Content-Type") == "application/json"
         ):
             data = json.dumps(data)
+        if stream:
+            kwargs["stream"] = stream
 
         parent_func = inspect.stack()[2][3]
         try:
             with sessions.Session() as session:
                 session.mount("http://", self.adapter)
                 session.mount("https://", self.adapter)
-                resp = session.request(method=method, url=url, data=data, **kwargs)
+                resp = session.request(
+                    method=method, url=url, data=data, timeout=timeout, **kwargs
+                )
         except requests.exceptions.Timeout:
             logger.warning(f"Request timeout: {method} {url}")
             raise
@@ -205,19 +210,27 @@ class BackendAPI:
         )
         return resp.json()
 
-    def get_ml_model_labels(self, model_id: int) -> Optional[BytesIO]:
+    def get_ml_model_labels(
+        self, model_id: int, timeout: int = 3000
+    ) -> requests.models.Response:
         resp = self.send_request(
             url=f"{self.host}/api/ml_models/{model_id}/labels/",
             method="get",
             headers=self.headers,
+            stream=True,
+            timeout=timeout,
         )
         return resp
 
-    def get_ml_model_file(self, model_id: int) -> Optional[BytesIO]:
+    def get_ml_model_file(
+        self, model_id: int, timeout: int = 3000
+    ) -> requests.models.Response:
         resp = self.send_request(
             url=f"{self.host}/api/ml_models/{model_id}/model/",
             method="get",
             headers=self.headers,
+            stream=True,
+            timeout=timeout,
         )
         return resp
 

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -362,7 +362,7 @@ class DataverseClient:
 
         Returns
         -------
-        tuple[bool, str]
+        (status, save_path): tuple[bool, str]
             the first item means whether the download success or not
             the second item shows the save_path
         """
@@ -398,7 +398,7 @@ class DataverseClient:
 
         Returns
         -------
-        tuple[bool, str]
+        (status, save_path): tuple[bool, str]
             the first item means whether the download success or not
             the second item shows the save_path
         """

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -331,14 +331,20 @@ class MLModel(BaseModel):
             triton_model_name=model_data["triton_model_name"],
         )
 
-    def get_label_file(self) -> dict:
+    def get_label_file(
+        self, save_path: str = "./labels.txt", timeout: int = 3000
+    ) -> tuple[bool, str]:
         from ..client import DataverseClient
 
-        labels: dict = DataverseClient.get_label_file(model_id=self.id)
-        return labels
+        return DataverseClient.get_label_file(
+            model_id=self.id, save_path=save_path, timeout=timeout
+        )
 
-    def get_triton_model_file(self):
+    def get_triton_model_file(
+        self, save_path: str = "./model.zip", timeout: int = 3000
+    ) -> tuple[bool, str]:
         from ..client import DataverseClient
 
-        model_file = DataverseClient.get_triton_model_file(model_id=self.id)
-        return model_file
+        return DataverseClient.get_triton_model_file(
+            model_id=self.id, save_path=save_path, timeout=timeout
+        )

--- a/python/dataverse_sdk/utils/utils.py
+++ b/python/dataverse_sdk/utils/utils.py
@@ -1,6 +1,8 @@
 from os import listdir
 from os.path import isfile, join
 
+import requests
+
 
 def get_filepaths(path: str) -> list[str]:
     dirs: list[str] = listdir(path)
@@ -12,3 +14,11 @@ def get_filepaths(path: str) -> list[str]:
         else:
             all_files.extend(get_filepaths(new_path))
     return all_files
+
+
+def download_file_from_response(response: requests.models.Response, save_path: str):
+    with open(save_path, "wb") as file:
+        for chunk in response.iter_content(1024 * 1024):
+            if chunk:
+                file.write(chunk)
+                file.flush()

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "0.1.4"
+PACKAGE_VERSION = "0.1.5"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose
- As title.
- [AB#14549](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/14549)

## What Changes?
- Add in download_file_from_response function in `utils.py`
- Modify `get_label_file` and `get_triton_model_file` for getting model related files. 

## What to Check?
### Get Model
```Python
model = client.get_model(model_id=30)
```
From the given model, we could download the label file and the triton model file by the commands below.
```Python
status, label_file_path = model.get_label_file(save_path="./labels.txt", timeout=6000)
status, triton_file_path = model.get_triton_model_file(save_path="./model.zip", timeout=6000)
```