### PR TITLE
chore(python): modify DataverseHost to adapt to AWS site

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -176,7 +176,7 @@ model = project.get_model(model_id=30)
 From the given model, we could get the label file and the triton model file by the commands below.
 ```Python
 status, label_file_path = model.get_label_file(save_path="./labels.txt", timeout=6000)
-status, label_file_path = model.get_triton_model_file(save_path="./model.zip", timeout=6000)
+status, triton_model_path = model.get_triton_model_file(save_path="./model.zip", timeout=6000)
 
 ```
 

--- a/python/dataverse_sdk/constants.py
+++ b/python/dataverse_sdk/constants.py
@@ -13,7 +13,9 @@ class BaseEnumMeta(EnumMeta):
 
 
 class DataverseHost(str, Enum, metaclass=BaseEnumMeta):
-    DEV = "https://dev.visionai.linkernetworks.ai"
-    STAGING = "https://staging.visionai.linkernetworks.ai"
-    DEMO = "https://demo.visionai.linkernetworks.ai"
+    DEV = "https://dev.dataverse.linkervision.ai"
+    DEV2 = "https://dev2.dataverse.linkervision.ai"
+    STAGING = "https://staging.dataverse.linkervision.ai"
+    DEMO = "https://demo.dataverse.linkervision.ai"
+    PUBLIC = "https://dataverse.linkervision.ai"
     LOCAL = "http://localhost:8000"

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "0.1.5"
+PACKAGE_VERSION = "0.2.0"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose
- As title.
- [AB#14937](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/14937)

## What Changes?
- Modify the `DataverseHost` to redirect users to AWS sites.
- Correct the typo in README.

## What to Check?
User can do things on AWS sites correctly.