### PR TITLE
feat(python): modify authenitcation of BackendAPI and DataverseClient

### DIFF
--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -47,21 +47,19 @@ class DataverseClient:
     def __init__(
         self,
         host: DataverseHost,
-        email: Optional[str] = None,
-        password: Optional[str] = None,
-        access_token: Optional[str] = None,
-        refresh_token: Optional[str] = None,
+        email: str,
+        password: str,
         alias: str = "default",
     ) -> None:
         """
         Instantiate a Dataverse client.
+
         Parameters
         ----------
         host : DataverseHost
-        email : Optional[str], optional
-        password : Optional[str], optional
-        access_token : Optional[str], optional
-        refresh_token : Optional[str], optional
+        email : str
+        password : str
+
         Raises
         ------
         ValueError
@@ -70,28 +68,19 @@ class DataverseClient:
             raise ValueError("Invalid dataverse host, if the host is available?")
         self.host = host
         self._api_client = None
-        self._init_api_client(
-            email=email,
-            password=password,
-            access_token=access_token,
-            refresh_token=refresh_token,
-        )
+        self._init_api_client(email=email, password=password)
         add_connection(alias=alias, conn=self)
 
     def _init_api_client(
         self,
-        email: Optional[str] = None,
-        password: Optional[str] = None,
-        access_token: Optional[str] = None,
-        refresh_token: Optional[str] = None,
+        email: str,
+        password: str,
     ) -> None:
         try:
             self._api_client = BackendAPI(
                 host=self.host,
                 email=email,
                 password=password,
-                access_token=access_token,
-                refresh_token=refresh_token,
             )
         except Exception as e:
             raise ClientConnectionError(f"Failed to initialize the api client: {e}")

--- a/python/dataverse_sdk/constants.py
+++ b/python/dataverse_sdk/constants.py
@@ -15,6 +15,7 @@ class BaseEnumMeta(EnumMeta):
 class DataverseHost(str, Enum, metaclass=BaseEnumMeta):
     DEV = "https://dev.dataverse.linkervision.ai"
     DEV2 = "https://dev2.dataverse.linkervision.ai"
+    DEV3 = "https://dev3.dataverse.linkervision.ai"
     STAGING = "https://staging.dataverse.linkervision.ai"
     DEMO = "https://demo.dataverse.linkervision.ai"
     PUBLIC = "https://dataverse.linkervision.ai"

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "0.2.1"
+PACKAGE_VERSION = "0.3.0"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose
To adapt the authentication change of Dataverse.

## What Changes?
- Remove `access_token` and `refresh_token` parameters of `BackendAPI` and `DataverseClient`.
- Add `DEV3` to `DataverseHost`.
- Change the package version from `0.2.1` to `0.3.0`

## What to Check?
People can use the SDK as before.

![image](https://github.com/linkernetworks/dataverse-sdk/assets/20389114/0200e1e8-3dac-47d3-8b1d-6d59ff381d69)
