### PR TITLE
fix(dataverse): don't call login API with invalid token header

### DIFF
--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -107,7 +107,7 @@ class BackendAPI:
         resp = self.send_request(
             url=f"{self.host}/auth/users/jwt/",
             method="post",
-            headers=self.headers,
+            headers={"Content-Type": "application/json"},
             data={"email": email, "password": password},
         )
         json_data = resp.json()

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "0.3.0"
+PACKAGE_VERSION = "0.3.1"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose
To `login()` without the invalid or expired token attached.

## What Changes?
- Fix the headers when we call /auth/users/jwt/ API.
- Change the package version from `0.3.0` to `0.3.1`

## What to Check?
Can login when the response is 401.
